### PR TITLE
Fix German translations

### DIFF
--- a/data/faq/de.json
+++ b/data/faq/de.json
@@ -5,19 +5,19 @@
       "questions": [
         {
           "question": "Was ist die Briefe App?",
-          "answer": "Die Letter App ist ein digitales Tool, mit dem Sie professionell formatierte Briefe auf Ihrem iPhone, iPad, Mac oder Android Gerät erstellen, weitergeben und drucken können. Sie verbindet die zeitlose Tradition des Briefversands mit modernem Komfort."
+          "answer": "Die Briefe App ist ein digitales Tool, mit dem Sie professionell formatierte Briefe auf Ihrem iPhone, iPad, Mac oder Android-Gerät erstellen, weitergeben und drucken können. Sie verbindet die zeitlose Tradition des Briefversands mit modernem Komfort."
         },
         {
           "question": "Warum sollte ich die Briefe App verwenden?",
           "answer": "Auch im Zeitalter der digitalen Kommunikation und der sofortigen Konnektivität bleibt der traditionelle Brief eine unverzichtbare Form der Korrespondenz. Offizielle Kommunikation wie Bewerbungen, Kündigungen, geschäftliche Angelegenheiten und vieles mehr wird oft noch per Brief erledigt. Traditionelle Briefe bieten eine Tiefe und Authentizität, die in der digitalen Kommunikation oft verloren geht. Mit der App können Sie diese Tradition aufrechterhalten und gleichzeitig die Einfachheit des Erstellens, Teilens und Bewahrens von Briefen im digitalen Zeitalter genießen."
         },
         {
-          "question": "Auf welchen Geräten kann ich die die Briefe App verwenden?",
-          "answer": "Die Letter App ist für iPhone, iPad, Mac und Android Geräte verfügbar."
+          "question": "Auf welchen Geräten kann ich die Briefe App verwenden?",
+          "answer": "Die Briefe App ist für iPhone, iPad, Mac und Android-Geräte verfügbar."
         },
         {
           "question": "Was sind die wichtigsten Funktionen von der Briefe App?",
-          "answer": "Die Brief-App bietet die folgenden Funktionen:",
+          "answer": "Die Briefe App bietet die folgenden Funktionen:",
           "items": [
             "Auto Format: Automatically formats your letters professionally.",
             "Print: Easily print your letters directly from the app.",

--- a/data/features.js
+++ b/data/features.js
@@ -70,7 +70,7 @@ const features = {
         icon: 'print',
       }, {
         title: 'Teilen & Exportieren',
-        description: 'Teilen Sie Ihre Briefe digital oder exportiere sie als PDF-Dateien',
+        description: 'Teilen Sie Ihre Briefe digital oder exportieren Sie sie als PDF-Dateien',
         icon: 'arrow-up-right-from-square',
       }, {
         title: 'Suche',

--- a/messages/de.json
+++ b/messages/de.json
@@ -1,12 +1,12 @@
 {
   "common": {
     "title": "Briefe App",
-    "title_long": "Briefe App - Mühelos professionelle Briefe auf iPhone, iPad, Mac und Android Geräten erstellen",
+    "title_long": "Briefe App - Mühelos professionelle Briefe auf iPhone, iPad, Mac und Android-Geräten erstellen",
     "scroll_down": "Nach unten scrollen",
     "language": "Deutsch",
     "download": "Herunterladen",
-    "android_only": "* Aktuell nicht Verfügbar auf Android Geräten",
-    "ios_only": "** Aktuell nur auf iPhone und iPad verfürgbar"
+    "android_only": "* Aktuell nicht verfügbar auf Android-Geräten",
+    "ios_only": "** Aktuell nur auf iPhone und iPad verfügbar"
   },
   "home": {
     "teaser": "Im Handumdrehen professionell formatierte Briefe erstellen und drucken."
@@ -33,7 +33,7 @@
     },
     "export": {
       "title": "Teilen & Exportieren",
-      "description": "Teilen Sie Ihre Briefe digital oder exportiere sie als PDF-Dateien"
+      "description": "Teilen Sie Ihre Briefe digital oder exportieren Sie sie als PDF-Dateien"
     },
     "sync": {
       "title": "Speicherung",
@@ -63,7 +63,7 @@
   "contact": {
     "title": "Kontakt",
     "subtitle": "Bitte kontaktieren Sie mich, wenn Sie Fragen haben",
-    "email_placeholder": "Ihre E-Mail Adresse",
+    "email_placeholder": "Ihre E-Mail-Adresse",
     "subject_placeholder": "Ihr Anliegen",
     "message_placeholder": "Ihre Nachricht",
     "privacy_1": "Ich akzeptiere die",
@@ -71,7 +71,7 @@
     "privacy_link": "/de/datenschutz",
     "privacy_info": "Ihre E-Mail-Adresse und Ihre Nachricht werden gespeichert, damit ich darauf antworten kann. Ihre Daten werden nicht für andere Zwecke verwendet.",
     "submit": "Senden",
-    "email_error": "Bitte geben Sie eine gültige E-Mail Adrese ein",
+    "email_error": "Bitte geben Sie eine gültige E-Mail-Adresse ein",
     "subject_error": "Bitte geben Sie Ihr Anliegen ein",
     "message_error": "Bitte geben Sie eine Nachricht ein",
     "captcha_error": "Bitte lösen Sie das Captcha",
@@ -81,7 +81,7 @@
     "cookie": "Bitte akzeptieren Sie die Cookies am unteren Rand des Bildschirms, um eine Nachricht zu übermitteln oder senden Sie eine E-Mail an support@briefe.app."
   },
   "footer": {
-    "rights": "alle Rechte vorbehalten.",
+    "rights": "Alle Rechte vorbehalten.",
     "imprint": "Impressum",
     "imprint_link": "/de/impressum",
     "privacy": "Datenschutzerklärung",


### PR DESCRIPTION
## Summary
- fix typos in German message translations
- fix export text in German feature list
- correct German FAQ wording

## Testing
- `yarn test` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_683d5e69fbbc8323a3c896003a5d3548