### PR TITLE
Improve site styling

### DIFF
--- a/components/Button.js
+++ b/components/Button.js
@@ -12,10 +12,10 @@ function Button({
       className="
       py-2
       px-4
-      border
       rounded-md
-      hover:bg-black
-      hover:text-white
+      text-white
+      bg-gradient-to-r from-blue to-blue-dark
+      hover:from-blue-dark hover:to-blue
       disabled:bg-gray-light
       disabled:text-gray"
     >

--- a/components/CallToActionClient.js
+++ b/components/CallToActionClient.js
@@ -3,7 +3,7 @@ import Image from 'next/image';
 
 export default function CallToActionClient({ text }) {
   return (
-    <div className="call-to-action bg-blue text-white mt-10 ml-3 mr-3 p-8">
+    <div className="call-to-action bg-gradient-to-r from-blue to-blue-dark text-white mt-10 ml-3 mr-3 p-8 rounded-md shadow-md">
       <div className="text-xl grid place-items-center">
         {text}
       </div>

--- a/components/Feature.js
+++ b/components/Feature.js
@@ -2,11 +2,11 @@ import React from 'react';
 
 export default function Feature({ icon, title, description }) {
   return (
-    <div className="flex mb-5">
-      <div className="text-4xl mr-5 w-16 pt-2 pl-1"><i className={`fa fa-${icon}`} /></div>
+    <div className="flex mb-5 p-4 rounded-lg shadow-lg bg-gray-light">
+      <div className="text-4xl mr-5 w-16 pt-2 pl-1 text-blue"><i className={`fa fa-${icon}`} /></div>
       <div className="w-full">
-        <div className="text-lg font-bold">{title}</div>
-        <div className="text-lg">{description}</div>
+        <div className="text-lg font-bold mb-1">{title}</div>
+        <div className="text-lg text-gray-dark">{description}</div>
       </div>
     </div>
   );

--- a/components/Heading.js
+++ b/components/Heading.js
@@ -3,12 +3,12 @@ import React from 'react';
 export default function Heading({ id, level = 1, children }) {
   switch (level) {
     case 1:
-      return (<h1 id={id} className="text-2xl pt-5 mb-6">{children}</h1>);
+      return (<h1 id={id} className="text-3xl md:text-4xl font-bold pt-5 mb-6">{children}</h1>);
     case 2:
-      return (<h2 id={id} className="text-xl pt-1 mb-4">{children}</h2>);
+      return (<h2 id={id} className="text-2xl font-semibold pt-1 mb-4">{children}</h2>);
     case 3:
-      return (<h3 id={id} className="text-2xl pt-5 mb-6">{children}</h3>);
+      return (<h3 id={id} className="text-xl font-semibold pt-5 mb-6">{children}</h3>);
     default:
-      return (<h1 id={id} className="text-2xl pt-5 mb-6">{children}</h1>);
+      return (<h1 id={id} className="text-3xl md:text-4xl font-bold pt-5 mb-6">{children}</h1>);
   }
 }

--- a/components/Home.js
+++ b/components/Home.js
@@ -22,7 +22,7 @@ export default function Home({ locale }) {
 
   return (
     <Page>
-      <Section className="grid place-items-center first bg-blue text-white">
+      <Section className="grid place-items-center first bg-gradient-to-b from-blue to-blue-dark text-white py-10">
         <Container className="grid place-items-center">
           <Image src={`/devices_${locale?.startsWith('de') ? 'de' : 'en'}.png`} alt="Letter app" width={992} height={605} unoptimized />
           <div className="grid grid-cols-2 gap-10">

--- a/components/NavigationClient.js
+++ b/components/NavigationClient.js
@@ -29,8 +29,8 @@ export default function Navigation({
   };
 
   return (
-    <header className="fixed top-0 w-full bg-blue text-white">
-      <div className="md:container px-4 my-4 fade-in flex flex-col md:flex-row">
+    <header className="fixed top-0 w-full bg-blue/90 backdrop-blur-md shadow-md text-white">
+      <div className="md:container px-4 py-3 fade-in flex flex-col md:flex-row">
         <div className="flex flex-grow">
           <Link href="/" className="flex items-center transition ease-in-out delay-150 flex-grow">
             <Image src="/logo.svg" alt="Letter logo" width={50} height={35} />

--- a/styles/base.css
+++ b/styles/base.css
@@ -7,11 +7,6 @@ body {
   color: #000;
 }
 
-header {
-  background-color:rgba(255, 255, 255, 0.8);
-  z-index: 100;
-}
-
 *:focus {
   outline: none;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -28,6 +28,9 @@ module.exports = {
       sans: ['Lexend', 'sans-serif'],
     },
     extend: {
+      colors: {
+        'blue-dark': '#0059b3',
+      },
       typography: ({ theme }) => ({
         briefe: {
           css: {


### PR DESCRIPTION
## Summary
- make navigation translucent and add drop shadow
- use gradient backgrounds for hero section and CTAs
- style feature list cards
- polish heading and button styles
- add `blue-dark` color in Tailwind config and clean base styles

## Testing
- `yarn test` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_683d621a8d0483239f13635713b07609