### PR TITLE
Fix Portuguese translations

### DIFF
--- a/data/faq/pt.json
+++ b/data/faq/pt.json
@@ -5,7 +5,7 @@
       "questions": [
         {
           "question": "O que é a aplicação Carta?",
-          "answer": "A aplicação Carta é uma ferramenta digital concebida para o ajudar a criar, partilhar e imprimir cartas com um formato profissional no iPhone, iPad, Mac e dispositivos andróides. Combina a tradição intemporal de enviar cartas com a conveniência moderna."
+          "answer": "A aplicação Carta é uma ferramenta digital concebida para o ajudar a criar, partilhar e imprimir cartas com um formato profissional no iPhone, iPad, Mac e dispositivos Android. Combina a tradição intemporal de enviar cartas com a conveniência moderna."
         },
         {
           "question": "Por que razão devo utilizar a aplicação Carta?",
@@ -13,7 +13,7 @@
         },
         {
           "question": "Em que dispositivos posso utilizar a aplicação Carta?",
-          "answer": "A aplicação Carta está disponível para dispositivos iPhone, iPad, Mac e dispositivos andróides."
+          "answer": "A aplicação Carta está disponível para dispositivos iPhone, iPad, Mac e dispositivos Android."
         },
         {
           "question": "Quais são as principais características da aplicação Carta?",
@@ -38,11 +38,11 @@
           ]
         },
         {
-          "question": "Como posso criar e formatar uma carta utilizando a aplicação a aplicação Carta?",
+          "question": "Como posso criar e formatar uma carta utilizando a aplicação Carta?",
           "answer": "Basta abrir a aplicação, criar uma nova carta e começar a escrever a sua mensagem. A aplicação formata-a automaticamente de forma profissional para si. Naturalmente, também pode personalizar as margens, o tipo de letra e muito mais nas definições da carta."
         },
         {
-          "question": "Posso imprimir cartas diretamente da aplicação a aplicação Carta?",
+          "question": "Posso imprimir cartas diretamente da aplicação Carta?",
           "answer": "Sim, pode imprimir as suas cartas diretamente a partir da aplicação com um simples toque no ícone de impressão."
         },
         {
@@ -55,7 +55,7 @@
         },
         {
           "question": "Posso aceder rapidamente a cartas compostas anteriormente?",
-          "answer": "Sim, a aplicação a aplicação Carta inclui uma função de pesquisa que facilita a procura e a recuperação das suas cartas previamente compostas."
+          "answer": "Sim, a aplicação Carta inclui uma função de pesquisa que facilita a procura e a recuperação das suas cartas previamente compostas."
         }
       ]
     },

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -1,11 +1,11 @@
 {
   "common": {
     "title": "Aplicação de Cartas",
-    "title_long": "Aplicação de Cartas - Crie cartas profissionais sem esforço no iPhone, iPad, Mac e dispositivos andróides",
+    "title_long": "Aplicação de Cartas - Crie cartas profissionais sem esforço no iPhone, iPad, Mac e dispositivos Android",
     "scroll_down": "Role para baixo",
     "language": "Português",
     "download": "Descarregar",
-    "android_only": "* atualmente não disponível em dispositivos andróides",
+    "android_only": "* atualmente não disponível em dispositivos Android",
     "ios_only": "** atualmente apenas no iPhone e no iPad"
   },
   "home": {
@@ -22,14 +22,14 @@
   },
   "features": {
     "title": "Recursos",
-    "description": "Para fornecer uma visão abrangente, listamos todos os recursos em detalhes, de acordo com sua disponibilidade nas diferentes versões do aplicação. Dessa forma, você pode ver facilmente quais recursos cada versão do aplicação oferece.",
+    "description": "Para fornecer uma visão abrangente, listamos todos os recursos em detalhes, de acordo com sua disponibilidade nas diferentes versões da aplicação. Dessa forma, você pode ver facilmente quais recursos cada versão da aplicação oferece.",
     "format": {
       "title": "Formatação Automática",
       "description": "As cartas são formatadas automaticamente de maneira profissional"
     },
     "print": {
       "title": "Imprimir",
-      "description": "Imprima facilmente suas cartas diretamente do aplicação"
+      "description": "Imprima facilmente suas cartas diretamente da aplicação"
     },
     "export": {
       "title": "Compartilhar e Exportar",
@@ -41,7 +41,7 @@
     },
     "signatures": {
       "title": "Assinaturas",
-      "description": "Adicione assinaturas pessoais diretamente no aplicação"
+      "description": "Adicione assinaturas pessoais diretamente na aplicação"
     },
     "contacts": {
       "title": "Contatos",
@@ -110,6 +110,6 @@
     "title": "Blog - Pensamentos, histórias e ideias"
   },
   "call_to_action": {
-    "text": "Baixe o aplicação de cartas agora e comece a escrever sua primeira carta — é grátis!"
+    "text": "Baixe a aplicação de cartas agora e comece a escrever sua primeira carta — é grátis!"
   }
 }


### PR DESCRIPTION
## Summary
- correct typos and grammar in Portuguese message catalog
- fix wording in Portuguese FAQ

## Testing
- `yarn test` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_683d6105db908323be8ab4792e30e588